### PR TITLE
v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# XLSXExporter
+# eclipxe13/XLSXExporter
 
 [![Source Code][badge-source]][source]
 [![Latest Version][badge-release]][release]
@@ -116,7 +116,7 @@ License MIT - Copyright (c) 2014 - 2016 Carlos Cortés Soto
 [coverage]: https://coveralls.io/github/eclipxe13/XLSXExporter?branch=master
 [downloads]: https://packagist.org/packages/eclipxe/xlsxexporter
 
-[badge-source]: http://img.shields.io/badge/source-eclipxe13/generic--collections-blue.svg?style=flat-square
+[badge-source]: http://img.shields.io/badge/source-eclipxe13/XLSXExporter-blue.svg?style=flat-square
 [badge-release]: https://img.shields.io/github/release/eclipxe13/XLSXExporter.svg?style=flat-square
 [badge-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
 [badge-build]: https://img.shields.io/travis/eclipxe13/XLSXExporter.svg?style=flat-square

--- a/sources/XLSXExporter/CellTypes.php
+++ b/sources/XLSXExporter/CellTypes.php
@@ -2,7 +2,7 @@
 
 namespace XLSXExporter;
 
-abstract class CellTypes
+interface CellTypes
 {
     const TEXT = 'TEXT';
     const NUMBER = 'NUMBER';

--- a/sources/XLSXExporter/Collection.php
+++ b/sources/XLSXExporter/Collection.php
@@ -2,6 +2,11 @@
 
 namespace XLSXExporter;
 
+/**
+ * Class Collection
+ * @access private
+ * @package XLSXExporter
+ */
 abstract class Collection implements \IteratorAggregate, \Countable
 {
     /**

--- a/sources/XLSXExporter/Collection.php
+++ b/sources/XLSXExporter/Collection.php
@@ -80,7 +80,7 @@ abstract class Collection implements \IteratorAggregate, \Countable
      */
     public function existsById($id, $start = 0)
     {
-        return (-1 !== $index = $this->searchById($id, $start));
+        return (-1 !== $this->searchById($id, $start));
     }
 
     /**

--- a/sources/XLSXExporter/Collection.php
+++ b/sources/XLSXExporter/Collection.php
@@ -2,7 +2,7 @@
 
 namespace XLSXExporter;
 
-abstract class AbstractCollection implements \IteratorAggregate, \Countable
+abstract class Collection implements \IteratorAggregate, \Countable
 {
     /**
      * @param mixed $item

--- a/sources/XLSXExporter/Columns.php
+++ b/sources/XLSXExporter/Columns.php
@@ -5,16 +5,26 @@ namespace XLSXExporter;
 class Columns extends AbstractCollection
 {
     /**
+     * Add a column to this collection
+     *
      * @param Column $item
      * @throws XLSXException
      */
     public function add($item)
     {
-        $this->addItem($item, ! $this->isValidInstance($item) ? null : $item->getId());
+        if (! $item instanceof Column) {
+            throw new XLSXException('Invalid Column object');
+        }
+        $this->collection[] = $item;
     }
 
-    public function isValidInstance($item)
+    /**
+     * @param string $id
+     * @param Column $item
+     * @return bool
+     */
+    protected function elementMatchId($id, $item)
     {
-        return ($item instanceof Column);
+        return ($id == $item->getId());
     }
 }

--- a/sources/XLSXExporter/Columns.php
+++ b/sources/XLSXExporter/Columns.php
@@ -2,7 +2,7 @@
 
 namespace XLSXExporter;
 
-class Columns extends AbstractCollection
+class Columns extends Collection
 {
     /**
      * Add a column to this collection

--- a/sources/XLSXExporter/DateConverter.php
+++ b/sources/XLSXExporter/DateConverter.php
@@ -30,7 +30,7 @@ class DateConverter
         $utc = static::utcParts($ts);
         // Bug 1900 is not a leap year
         // http://support.microsoft.com/kb/214326
-        $delta = ($utc[0] == 1900 and $utc[1] <= 2) ? -1 : 0;
+        $delta = ($utc[0] == 1900 && $utc[1] <= 2) ? -1 : 0;
         return (int) (25569 + $delta + (($ts + $utc[6]) / 86400));
     }
 

--- a/sources/XLSXExporter/DateConverter.php
+++ b/sources/XLSXExporter/DateConverter.php
@@ -8,42 +8,42 @@ class DateConverter
     const DATE = 'DATE';
     const DATETIME = 'DATETIME';
 
-    public static function tsToExcel($ts, $type)
+    public static function tsToExcel($timestamp, $type)
     {
         if ($type === self::TIME) {
-            return static::tsToExcelTime($ts);
+            return static::tsToExcelTime($timestamp);
         }
         if ($type === self::DATE) {
-            return static::tsToExcelDate($ts);
+            return static::tsToExcelDate($timestamp);
         }
-        return static::tsToExcelDateTime($ts);
+        return static::tsToExcelDateTime($timestamp);
     }
 
-    public static function tsToExcelTime($ts)
+    public static function tsToExcelTime($timestamp)
     {
-        $utc = static::utcParts($ts);
+        $utc = static::utcParts($timestamp);
         return (($utc[3] * 3600) + ($utc[4] * 60) + $utc[5]) / 86400;
     }
 
-    public static function tsToExcelDate($ts)
+    public static function tsToExcelDate($timestamp)
     {
-        $utc = static::utcParts($ts);
+        $utc = static::utcParts($timestamp);
         // Bug 1900 is not a leap year
         // http://support.microsoft.com/kb/214326
         $delta = ($utc[0] == 1900 && $utc[1] <= 2) ? -1 : 0;
-        return (int) (25569 + $delta + (($ts + $utc[6]) / 86400));
+        return (int) (25569 + $delta + (($timestamp + $utc[6]) / 86400));
     }
 
-    public static function tsToExcelDateTime($ts)
+    public static function tsToExcelDateTime($timestamp)
     {
-        return (float) static::tsToExcelDate($ts) + static::tsToExcelTime($ts);
+        return (float) static::tsToExcelDate($timestamp) + static::tsToExcelTime($timestamp);
     }
 
-    public static function utcParts($ts)
+    public static function utcParts($timestamp)
     {
-        $offset = date('Z', $ts);
+        $offset = date('Z', $timestamp);
         return array_merge(
-            explode(',', gmdate('Y,m,d,H,i,s', $ts + $offset)),
+            explode(',', gmdate('Y,m,d,H,i,s', $timestamp + $offset)),
             [$offset]
         );
     }

--- a/sources/XLSXExporter/Providers/NullProvider.php
+++ b/sources/XLSXExporter/Providers/NullProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace XLSXExporter\Providers;
+
+use XLSXExporter\ProviderInterface;
+
+/**
+ * This is a NullProvider
+ *
+ * @package XLSXExporter\Providers
+ */
+class NullProvider implements ProviderInterface
+{
+    public function get($key)
+    {
+        return null;
+    }
+
+    public function next()
+    {
+    }
+
+    public function valid()
+    {
+        return false;
+    }
+
+    public function count()
+    {
+        return 0;
+    }
+}

--- a/sources/XLSXExporter/Providers/ProviderArray.php
+++ b/sources/XLSXExporter/Providers/ProviderArray.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace XLSXExporter;
+namespace XLSXExporter\Providers;
 
+use XLSXExporter\ProviderInterface;
 use XLSXExporter\Utils\ProviderGetValue;
 
 class ProviderArray implements ProviderInterface

--- a/sources/XLSXExporter/Providers/ProviderIterator.php
+++ b/sources/XLSXExporter/Providers/ProviderIterator.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace XLSXExporter;
+namespace XLSXExporter\Providers;
 
 use Iterator;
+use XLSXExporter\ProviderInterface;
 use XLSXExporter\Utils\ProviderGetValue;
 
 /**

--- a/sources/XLSXExporter/Style.php
+++ b/sources/XLSXExporter/Style.php
@@ -72,9 +72,9 @@ class Style
     {
         $getter = (0 === strpos($name, 'get'));
         $setter = (0 === strpos($name, 'set'));
-        if ($getter or $setter) {
+        if ($getter || $setter) {
             $name = lcfirst(substr($name, 3));
-        } elseif (! $getter and ! $setter) {
+        } elseif (! $getter && ! $setter) {
             throw new \LogicException("Invalid method name $name");
         }
         if (! array_key_exists($name, $this->members)) {
@@ -107,7 +107,7 @@ class Style
             return $this;
         }
         foreach ($this->members as $key => $style) {
-            if (array_key_exists($key, $array) and is_array($array[$key])) {
+            if (array_key_exists($key, $array) && is_array($array[$key])) {
                 $style->setValues($array[$key]);
             }
         }

--- a/sources/XLSXExporter/StyleSheet.php
+++ b/sources/XLSXExporter/StyleSheet.php
@@ -76,12 +76,12 @@ class StyleSheet
         $generic->setIndex(0);
         if ($generic->hasValues()) {
             $hash = $generic->getHash();
-            if (false === $i = array_search($hash, $this->hashes[$name], true)) {
-                $i = count($this->hashes[$name]);
+            if (false === $index = array_search($hash, $this->hashes[$name], true)) {
+                $index = count($this->hashes[$name]);
                 array_push($this->hashes[$name], $hash);
                 array_push($this->objects[$name], $generic);
             }
-            $generic->setIndex($i);
+            $generic->setIndex($index);
         }
     }
 
@@ -107,8 +107,8 @@ class StyleSheet
     protected function xmlCollection($name, $tag)
     {
         return '<' . $tag . ' count="' . count($this->objects[$name]) . '">'
-            . array_reduce($this->objects[$name], function ($r, Styles\StyleInterface $generic) {
-                return $r . $generic->asXML();
+            . array_reduce($this->objects[$name], function ($return, Styles\StyleInterface $generic) {
+                return $return . $generic->asXML();
             })
             . '</' . $tag . '>'
         ;
@@ -124,12 +124,12 @@ class StyleSheet
 
     protected function xmlCellXfs()
     {
-        $i = 0;
+        $index = 0;
         return '<cellXfs count="' . count($this->styles) . '">'
-            . array_reduce($this->styles, function ($r, Style $style) use (&$i) {
-                $style->setStyleIndex($i);
-                $i = $i + 1;
-                return $r . $style->asXML();
+            . array_reduce($this->styles, function ($return, Style $style) use (&$index) {
+                $style->setStyleIndex($index);
+                $index = $index + 1;
+                return $return . $style->asXML();
             })
             . '</cellXfs>'
         ;

--- a/sources/XLSXExporter/StyleSheet.php
+++ b/sources/XLSXExporter/StyleSheet.php
@@ -127,8 +127,6 @@ class StyleSheet
         $i = 0;
         return '<cellXfs count="' . count($this->styles) . '">'
             . array_reduce($this->styles, function ($r, Style $style) use (&$i) {
-                // // if no values then do not include
-                // if (!$style->hasValues()) return $r;
                 $style->setStyleIndex($i);
                 $i = $i + 1;
                 return $r . $style->asXML();

--- a/sources/XLSXExporter/Styles/Fill.php
+++ b/sources/XLSXExporter/Styles/Fill.php
@@ -25,7 +25,7 @@ class Fill extends AbstractStyle
 
     public function asXML()
     {
-        if (! $this->pattern or $this->pattern == static::NONE or $this->pattern === static::GRAY125) {
+        if (! $this->pattern || $this->pattern == static::NONE || $this->pattern === static::GRAY125) {
             return '<fill><patternFill patternType="' . $this->pattern . '"/></fill>';
         }
         return '<fill>'

--- a/sources/XLSXExporter/WorkBook.php
+++ b/sources/XLSXExporter/WorkBook.php
@@ -16,18 +16,16 @@ class WorkBook
     /** @var Style default base style */
     protected $style;
 
-    public function __construct($worksheets = null, $style = null)
+    /**
+     * WorkBook constructor.
+     *
+     * @param WorkSheets|null $worksheets
+     * @param Style|null $style
+     */
+    public function __construct(WorkSheets $worksheets = null, Style $style = null)
     {
-        // wroksheets
-        if (! ($worksheets instanceof WorkSheets)) {
-            $worksheets = new WorkSheets();
-        }
-        $this->worksheets = $worksheets;
-        // style
-        if (! ($style instanceof Style)) {
-            $style = BasicStyles::defaultStyle();
-        }
-        $this->style = $style;
+        $this->worksheets = ($worksheets) ? : new WorkSheets();
+        $this->style = ($style) ? : BasicStyles::defaultStyle();
     }
 
     public function __get($name)

--- a/sources/XLSXExporter/WorkBook.php
+++ b/sources/XLSXExporter/WorkBook.php
@@ -74,13 +74,13 @@ class WorkBook
             $zip->addFromString('xl/_rels/workbook.xml.rels', $this->xmlWorkbookRels());
             // create the sharedStrings object because worksheets use it
             $sharedstrings = new SharedStrings();
-            $i = 1;
+            $wsIndex = 1;
             foreach ($this->worksheets as $worksheet) {
                 // write and include the sheet
                 $wsfile = $worksheet->write($sharedstrings);
                 $removefiles[] = $wsfile;
-                $zip->addFile($wsfile, $this->workSheetFilePath($i));
-                $i = $i + 1;
+                $zip->addFile($wsfile, $this->workSheetFilePath($wsIndex));
+                $wsIndex = $wsIndex + 1;
             }
             // include the shared strings file
             $shstrsfile = $sharedstrings->write();
@@ -126,8 +126,8 @@ class WorkBook
             . ' ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>'
             . '<Override PartName="/xl/sharedStrings.xml"'
             . ' ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>'
-            . array_reduce(range(1, $this->worksheets->count()), function ($r, $index) {
-                return $r . '<Override PartName="/' . $this->workSheetFilePath($index)
+            . array_reduce(range(1, $this->worksheets->count()), function ($return, $index) {
+                return $return . '<Override PartName="/' . $this->workSheetFilePath($index)
                     . '" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>'
                 ;
             })

--- a/sources/XLSXExporter/WorkBook.php
+++ b/sources/XLSXExporter/WorkBook.php
@@ -50,6 +50,11 @@ class WorkBook
         if (! $this->worksheets->count()) {
             throw new XLSXException('Workbook does not contains any worksheet');
         }
+        // check that every sheet has a different name
+        $repeatedNames = $this->worksheets->retrieveRepeatedNames();
+        if (count($repeatedNames)) {
+            throw new XLSXException('Workbook has worksheets with the same name: ' . implode(',', $repeatedNames));
+        }
         // validations end, create the file
         $filename = tempnam(sys_get_temp_dir(), 'xlsx-');
         $removefiles = [];

--- a/sources/XLSXExporter/WorkSheet.php
+++ b/sources/XLSXExporter/WorkSheet.php
@@ -2,10 +2,15 @@
 
 namespace XLSXExporter;
 
+use XLSXExporter\Providers\NullProvider;
+
 /**
- * @property-read Columns|Column[] $columns Columns object
- * @property-read string $name Name of the worksheet
- * @property-read Style $headerstyle Style of the header columns
+ * WorkSheet class
+ *
+ * @property ProviderInterface $provider Provider object
+ * @property Columns|Column[] $columns Columns object
+ * @property string $name Name of the worksheet
+ * @property Style $headerStyle Style of the header columns
  */
 class WorkSheet
 {
@@ -19,27 +24,40 @@ class WorkSheet
     protected $provider;
 
     /** @var Style */
-    protected $headerstyle;
+    protected $headerStyle;
 
-    public function __construct($name, $provider = null, $columns = null, $headerstyle = null)
-    {
+    /**
+     * WorkSheet constructor.
+     *
+     * @param string $name
+     * @param ProviderInterface $provider
+     * @param Columns $columns
+     * @param Style $headerStyle
+     */
+    public function __construct(
+        $name,
+        ProviderInterface $provider = null,
+        Columns $columns = null,
+        Style $headerStyle = null
+    ) {
         $this->setName($name);
-        if (! ($columns instanceof Columns)) {
-            $columns = new Columns();
-        }
-        $this->setColumns($columns);
-        if ($provider instanceof ProviderInterface) {
-            $this->setProvider($provider);
-        }
-        if (! ($headerstyle instanceof Style)) {
-            $headerstyle = BasicStyles::defaultHeader();
-        }
-        $this->setHeaderStyle($headerstyle);
+        $this->setProvider(($provider) ? : new NullProvider());
+        $this->setColumns(($columns) ? : new Columns());
+        $this->setHeaderStyle(($headerStyle) ? : BasicStyles::defaultHeader());
     }
 
+    /**
+     * Magic method, this allow to access methods as getters:
+     * - name => getName
+     * - columns => getColumns
+     *
+     * @param string $name
+     * @return mixed
+     * @throws XLSXException
+     */
     public function __get($name)
     {
-        $props = ['name', 'columns'];
+        $props = ['name', 'provider', 'columns', 'headerStyle'];
         if (! in_array($name, $props)) {
             throw new XLSXException("Invalid property name $name");
         }
@@ -47,11 +65,24 @@ class WorkSheet
         return $this->$method();
     }
 
+    /**
+     * @return string Worksheet name
+     */
     public function getName()
     {
         return $this->name;
     }
 
+    /**
+     * Set the name of the sheet, be aware that the name has several constraints:
+     * - Must be a string
+     * - Cannot contains: : \ / ? * [ ] ' tab nl cr null
+     * - Cannot be more than 31 chars
+     * - Cannot be an empty string
+     *
+     * @param string $name
+     * @throws XLSXException
+     */
     public function setName($name)
     {
         if (! is_string($name)) {
@@ -70,36 +101,72 @@ class WorkSheet
         $this->name = $name;
     }
 
+    /**
+     * Retrieve the columns collection object
+     *
+     * @return Column[]|Columns
+     */
     public function getColumns()
     {
         return $this->columns;
     }
 
+    /**
+     * Set the columns collection object
+     *
+     * @param Columns $columns
+     */
     public function setColumns(Columns $columns)
     {
         $this->columns = $columns;
     }
 
+    /**
+     * Retrieve the header style
+     *
+     * @return Style
+     */
     public function getHeaderStyle()
     {
-        return $this->headerstyle;
+        return $this->headerStyle;
     }
 
-    public function setHeaderStyle(Style $headerstyle)
+    /**
+     * Set the header style
+     * @param Style $headerStyle
+     */
+    public function setHeaderStyle(Style $headerStyle)
     {
-        $this->headerstyle = $headerstyle;
+        $this->headerStyle = $headerStyle;
     }
 
+    /**
+     * Set the provider object
+     *
+     * @param ProviderInterface $provider
+     */
     public function setProvider(ProviderInterface $provider)
     {
         $this->provider = $provider;
     }
 
+    /**
+     * Retrieve the provider object, null if the object has not been set
+     *
+     * @return ProviderInterface
+     */
     public function getProvider()
     {
         return $this->provider;
     }
 
+    /**
+     * Write the contents of the worksheet, it requires a SharedStrings object
+     *
+     * @param SharedStrings $strings
+     * @return string
+     * @throws XLSXException
+     */
     public function write(SharedStrings $strings)
     {
         $tempfile = tempnam(sys_get_temp_dir(), 'ws-');
@@ -107,17 +174,14 @@ class WorkSheet
         $writer->createSheet($tempfile, $this->columns->count(), $this->provider->count());
         $writer->openSheet();
         // -- write headers contents
-        {
-            // write new row
-            $writer->openRow();
-            $styleindex = $this->getHeaderStyle()->getStyleIndex();
+        $writer->openRow();
+        $styleindex = $this->getHeaderStyle()->getStyleIndex();
         foreach ($this->columns as $column) {
             // write cell
             $s = $strings->add($column->getTitle());
             $writer->writeCell(CellTypes::TEXT, $s, $styleindex);
         }
-            $writer->closeRow();
-        }
+        $writer->closeRow();
         // -- write cell contents
         while ($this->provider->valid()) {
             // write new row

--- a/sources/XLSXExporter/WorkSheet.php
+++ b/sources/XLSXExporter/WorkSheet.php
@@ -54,7 +54,19 @@ class WorkSheet
 
     public function setName($name)
     {
-        // TODO: Validate correct names for worksheets
+        if (! is_string($name)) {
+            throw new XLSXException('Invalid worksheet name, is not a string');
+        }
+        if ('' === $name) {
+            throw new XLSXException('Invalid worksheet name, is empty');
+        }
+        $castedName = preg_replace('/[\'\/\\\\:\?\*\[\]\n\r\t\0]/', '', $name);
+        if ($name !== $castedName) {
+            throw new XLSXException('Invalid worksheet name, contains invalid chars');
+        }
+        if (strlen($castedName) > 31) {
+            throw new XLSXException('Invalid worksheet name, is more than 31 chars length');
+        }
         $this->name = $name;
     }
 

--- a/sources/XLSXExporter/WorkSheets.php
+++ b/sources/XLSXExporter/WorkSheets.php
@@ -2,7 +2,7 @@
 
 namespace XLSXExporter;
 
-class WorkSheets extends AbstractCollection
+class WorkSheets extends Collection
 {
     /**
      * Add a WorkSheet to this collection

--- a/sources/XLSXExporter/WorkSheets.php
+++ b/sources/XLSXExporter/WorkSheets.php
@@ -5,16 +5,46 @@ namespace XLSXExporter;
 class WorkSheets extends AbstractCollection
 {
     /**
+     * Add a WorkSheet to this collection
+     *
      * @param WorkSheet $item
      * @throws XLSXException
      */
     public function add($item)
     {
-        $this->addItem($item, ! $this->isValidInstance($item) ? null : $item->getName());
+        if (! $item instanceof WorkSheet) {
+            throw new XLSXException('Invalid WorkSheet object');
+        }
+        $this->collection[] = $item;
     }
 
-    public function isValidInstance($item)
+    /**
+     * Return the repeated worksheet names
+     *
+     * @return array
+     */
+    public function retrieveRepeatedNames()
     {
-        return ($item instanceof WorkSheet);
+        $names = [];
+        $repeated = [];
+        foreach ($this->collection as $worksheet) {
+            /* @var $worksheet WorkSheet */
+            if (! in_array($worksheet->getName(), $names)) {
+                $names[] = $worksheet->getName();
+                continue;
+            }
+            $repeated[] = $worksheet->getName();
+        }
+        return array_unique($repeated);
+    }
+
+    /**
+     * @param string $id
+     * @param WorkSheet $item
+     * @return bool
+     */
+    protected function elementMatchId($id, $item)
+    {
+        return ($id == $item->getName());
     }
 }

--- a/tests/classes/XLSXExporterTests/ColumnsTest.php
+++ b/tests/classes/XLSXExporterTests/ColumnsTest.php
@@ -11,7 +11,7 @@ class ColumnsTest extends \PHPUnit_Framework_TestCase
     public function testConstructMinimalParameters()
     {
         $o = new Columns();
-        $this->assertInstanceOf("XLSXExporter\\Columns", $o);
+        $this->assertInstanceOf(Columns::class, $o);
         $this->assertInternalType("array", $o->all());
         $this->assertCount(0, $o->all());
         $this->assertEquals(0, $o->count());
@@ -22,21 +22,17 @@ class ColumnsTest extends \PHPUnit_Framework_TestCase
         $c = new Column("foo");
         $o = new Columns();
         $o->add($c);
-        $this->assertEquals(1, $o->count(), "The count must be 1");
-        $this->assertCount(1, $o->all(), "The count of all must be 1");
-        $a = $o->all();
-        $this->assertArrayHasKey("foo", $a, "method all must return an array with a key");
-        $this->assertInstanceOf("XLSXExporter\\Column", $a["foo"]);
+        $this->assertCount(1, $o, "The count must be 1");
+        $this->assertSame([$c], $o->all(), "The contents of the columns is not the same");
     }
 
-    public function testAddAvoidDuplicity()
+    public function testAddAllowDuplicity()
     {
         $c = new Column("foo");
         $o = new Columns();
         $o->add($c);
-        $this->expectException(XLSXException::class);
-        $this->expectExceptionMessage("There is a item with the same id, ids must be unique");
         $o->add($c);
+        $this->assertCount(2, $o);
     }
 
     public function testGetColumn()
@@ -44,35 +40,31 @@ class ColumnsTest extends \PHPUnit_Framework_TestCase
         $c = new Column("foo");
         $o = new Columns();
         $o->add($c);
-        $this->assertInstanceOf("XLSXExporter\\Column", $o->get("foo"));
-        $this->assertTrue($o->exists("foo"));
-        $this->assertFalse($o->exists("baz"));
+        $this->assertInstanceOf(Column::class, $o->getById("foo"));
+        $this->assertTrue($o->existsById("foo"));
+        $this->assertFalse($o->existsById("baz"));
         $this->expectException(XLSXException::class);
         $this->expectExceptionMessage("The item baz does not exists");
-        $o->get("baz");
+        $o->getById("baz");
     }
 
     public function testAddArrayOnlyAllowColumnObjects()
     {
         $o = new Columns();
         $this->expectException(XLSXException::class);
-        $this->expectExceptionMessage("The item is not a valid object for the collection");
+        $this->expectExceptionMessage("Invalid Column object");
         $o->addArray([ new Column("foo"), new \stdClass(), new Column("bar") ]);
     }
 
     public function testCommonUsage()
     {
-        $o = new Columns();
-        $o->addArray([
+        $expectedArray = [
             new Column("foo"),
             new Column("bar"),
             new Column("baz"),
-        ]);
-        $this->assertEquals(3, $o->count(), "The count must be 3");
-        $this->assertCount(3, $o->all(), "The count of all must be 3");
-        foreach ($o as $key => $value) {
-            $this->assertTrue(in_array($key, ["foo", "bar", "baz"]));
-            $this->assertInstanceOf("XLSXExporter\\Column", $value);
-        }
+        ];
+        $o = new Columns();
+        $o->addArray($expectedArray);
+        $this->assertSame($expectedArray, $o->all());
     }
 }

--- a/tests/classes/XLSXExporterTests/CompleteTest.php
+++ b/tests/classes/XLSXExporterTests/CompleteTest.php
@@ -2,7 +2,7 @@
 
 namespace XLSXExporterTests;
 
-use XLSXExporter\ProviderArray;
+use XLSXExporter\Providers\ProviderArray;
 use XLSXExporter\WorkBook;
 use XLSXExporter\WorkSheet;
 use XLSXExporter\WorkSheets;

--- a/tests/classes/XLSXExporterTests/CompleteTest.php
+++ b/tests/classes/XLSXExporterTests/CompleteTest.php
@@ -31,7 +31,7 @@ class CompleteTest extends \PHPUnit_Framework_TestCase
                     "amount",
                     "Amount",
                     CellTypes::NUMBER,
-                    (new Style())->setFromArray([
+                    new Style([
                         "format" => ["code" => Format::FORMAT_COMMA_2DECS],
                         "font" => ["bold" => 1]
                     ])
@@ -40,7 +40,7 @@ class CompleteTest extends \PHPUnit_Framework_TestCase
                     "visit",
                     "Visit",
                     CellTypes::DATETIME,
-                    (new Style())->setFromArray([
+                    new Style([
                         "format" => ["code" => Format::FORMAT_DATE_YMDHM],
                         "protection" => ["hidden" => 1, "locked" => 1]
                     ])
@@ -49,7 +49,7 @@ class CompleteTest extends \PHPUnit_Framework_TestCase
                     "check",
                     "Check",
                     CellTypes::BOOLEAN,
-                    (new Style())->setFromArray([
+                    new Style([
                         "format" => ["code" => Format::FORMAT_YESNO],
                         "alignment" => Alignment::HORIZONTAL_CENTER
                     ])

--- a/tests/classes/XLSXExporterTests/WorkSheetTest.php
+++ b/tests/classes/XLSXExporterTests/WorkSheetTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace classes\XLSXExporterTests;
+
+use PHPUnit\Framework\TestCase;
+use XLSXExporter\WorkSheet;
+use XLSXExporter\XLSXException;
+
+class WorkSheetTest extends TestCase
+{
+    /** @var WorkSheet */
+    private $worksheet;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->worksheet = new WorkSheet('Sheet1');
+    }
+
+    public function testWorkSheetGetName()
+    {
+        $this->assertSame('Sheet1', $this->worksheet->getName());
+        $this->assertSame('Sheet1', $this->worksheet->name);
+    }
+
+    public function testWorkSheetSetName()
+    {
+        $this->worksheet->setName('foo');
+        $this->assertSame('foo', $this->worksheet->getName());
+    }
+
+    public function testWorkSheetSetNameWithNotAString()
+    {
+        $this->expectException(XLSXException::class);
+        $this->expectExceptionMessage('Invalid worksheet name, is not a string');
+        $this->worksheet->setName(null);
+    }
+
+    public function testWorkSheetSetNameWithEmptyString()
+    {
+        $this->expectException(XLSXException::class);
+        $this->expectExceptionMessage('Invalid worksheet name, is empty');
+        $this->worksheet->setName('');
+    }
+
+    public function testWorkSheetSetNameWithLongString()
+    {
+        $expected = str_repeat('x', 31);
+        $this->worksheet->setName($expected);
+        $this->assertSame($expected, $this->worksheet->getName());
+        $this->expectException(XLSXException::class);
+        $this->expectExceptionMessage('Invalid worksheet name, is more than 31 chars length');
+        $this->worksheet->setName(str_repeat('x', 32));
+    }
+
+    public function providerWorkSheetSetNameWithInvalidString()
+    {
+        return [[':'], ['/'], ['\\'], ['?'], ['*'], ['['], [']'], ["'"], ["\t"], ["\r"], ["\n"], ["\0"]];
+    }
+
+    /**
+     * @param $name
+     * @dataProvider providerWorkSheetSetNameWithInvalidString
+     */
+    public function testWorkSheetSetNameWithInvalidString($name)
+    {
+        $this->expectException(XLSXException::class);
+        $this->expectExceptionMessage('Invalid worksheet name, contains invalid chars');
+        $this->worksheet->setName($name);
+    }
+}

--- a/tests/classes/XLSXExporterTests/WorkSheetsTest.php
+++ b/tests/classes/XLSXExporterTests/WorkSheetsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace classes\XLSXExporterTests;
+
+use PHPUnit\Framework\TestCase;
+use XLSXExporter\Collection;
+use XLSXExporter\WorkSheet;
+use XLSXExporter\WorkSheets;
+use XLSXExporter\XLSXException;
+
+class WorkSheetsTest extends TestCase
+{
+    /** @var WorkSheets */
+    private $worksheets;
+
+    protected function setUp()
+    {
+        $this->worksheets = new WorkSheets();
+    }
+
+
+    public function testConstructor()
+    {
+        $this->assertInstanceOf(Collection::class, $this->worksheets);
+        $this->assertCount(0, $this->worksheets);
+    }
+
+    public function testAdd()
+    {
+        $foo = new WorkSheet('foo');
+        $bar = new WorkSheet('bar');
+        $this->worksheets->add($foo);
+        $this->worksheets->add($bar);
+        $this->assertSame([$foo, $bar], $this->worksheets->all());
+    }
+
+    public function providerAddThrowsException()
+    {
+        return [[null], [new \stdClass()], ['foo']];
+    }
+
+    /**
+     * @dataProvider providerAddThrowsException
+     * @param $element
+     */
+    public function testAddThrowsException($element)
+    {
+        $this->expectException(XLSXException::class);
+        $this->expectExceptionMessage('Invalid WorkSheet object');
+        $this->worksheets->add($element);
+    }
+
+    public function testRetrieveRepeatedNames()
+    {
+        $foo = new WorkSheet('xxx');
+        $bar = new WorkSheet('xxx');
+        $baz = new WorkSheet('zzz');
+        $this->worksheets->addArray([$foo, $bar, $baz]);
+        $repeated = $this->worksheets->retrieveRepeatedNames();
+        $expected = ['xxx'];
+        $this->assertSame($expected, $repeated);
+    }
+}


### PR DESCRIPTION
Small API breaks:
- remove `AbstractCollection`
- add `Collection`

Improvements:
- rules for worksheet names are followed
- cannot create a document with two or more worksheets with the same name
- constructors, type hints, docblocks, tests
