### PR TITLE
Version 1.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ sudo: false
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-dist
+  - travis_retry composer require --no-interaction --prefer-dist --dev scrutinizer/ocular
 
 script:
   - mkdir -p build/tests/
@@ -27,7 +28,7 @@ script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=build/tests/coverage.xml
 
 after_script:
-  - if [[ $TRAVIS_PHP_VERSION == '5.6' ]]; then php vendor/bin/ocular code-coverage:upload --format=php-clover build/tests/coverage.xml; fi
+  - if [[ $TRAVIS_PHP_VERSION == '7.0' ]]; then php vendor/bin/ocular code-coverage:upload --format=php-clover build/tests/coverage.xml; fi
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
+# Version 1.5.5
+- Fix bug when the array in the ProviderArray has non consecutive keys
+- Improve ProviderIterator, use count() method if the $iterator parameter is an instance of \Countable
+- Set composer specific versions, remove scrutinizer/ocular from dev, install only on inside travis build
+- Minor changes in typos, dockblocks and code style
+
 # Version 1.5.4
-- Fix bad namespace used on dome tests files
+- Fix bad namespace used on some tests files
 
 # Version 1.5.3
 - Enable php 7.1 due engineworks-dbal works again

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "eclipxe/engineworks-dbal": "^1.6",
-        "phpunit/phpunit": "^6.1",
+        "phpunit/phpunit": "^5.7",
         "jakub-onderka/php-parallel-lint": "^0.9",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.3.2"

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "phpunit/phpunit": "^6.1",
         "jakub-onderka/php-parallel-lint": "^0.9",
         "squizlabs/php_codesniffer": "^3.0",
-        "friendsofphp/php-cs-fixer": "^2.3.2",
-        "scrutinizer/ocular": "@stable"
+        "friendsofphp/php-cs-fixer": "^2.3.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,17 +13,17 @@
     "require": {
         "php": ">=5.6",
         "ext-zip": "*",
-        "eclipxe/engineworks-progress-status": "@stable"
+        "eclipxe/engineworks-progress-status": "^1.0"
     },
     "suggest": {
         "eclipxe/engineworks-dbal": "Export recordsets as worksheets in a workbook"
     },
     "require-dev": {
-        "eclipxe/engineworks-dbal": "@stable",
-        "phpunit/phpunit": "@stable",
-        "jakub-onderka/php-parallel-lint": "@stable",
-        "squizlabs/php_codesniffer": "@stable",
-        "friendsofphp/php-cs-fixer": "@stable",
+        "eclipxe/engineworks-dbal": "^1.6",
+        "phpunit/phpunit": "^6.1",
+        "jakub-onderka/php-parallel-lint": "^0.9",
+        "squizlabs/php_codesniffer": "^3.0",
+        "friendsofphp/php-cs-fixer": "^2.3.2",
         "scrutinizer/ocular": "@stable"
     },
     "autoload": {

--- a/src/XLSXExporter/Collection.php
+++ b/src/XLSXExporter/Collection.php
@@ -4,6 +4,7 @@ namespace XLSXExporter;
 /**
  * Class Collection
  * @access private
+ *
  * @package XLSXExporter
  */
 abstract class Collection implements \IteratorAggregate, \Countable

--- a/src/XLSXExporter/DBAL/RecordsetProvider.php
+++ b/src/XLSXExporter/DBAL/RecordsetProvider.php
@@ -4,6 +4,12 @@ namespace XLSXExporter\DBAL;
 use EngineWorks\DBAL\Recordset;
 use XLSXExporter\ProviderInterface;
 
+/**
+ * The RecordsetProvider uses a Recordset object as a Provider
+ * Important: This class will not move the current record but forward (it will not rewind)
+ *
+ * @package XLSXExporter\DBAL
+ */
 class RecordsetProvider implements ProviderInterface
 {
     /** @var Recordset */

--- a/src/XLSXExporter/ProviderInterface.php
+++ b/src/XLSXExporter/ProviderInterface.php
@@ -1,6 +1,32 @@
 <?php
 namespace XLSXExporter;
 
+/**
+ * Interface ProviderInterface
+ *
+ * The providers are very similar to Iterator but its not the same.
+ * The objects that implement this interface will be used like:
+ *
+ * $totalRecords = $provider->count();
+ * while($provider->valid()) {
+ *     $provider->get($key);
+ *     $provider->next();
+ * }
+ *
+ * If the provider does not implement correctly the total count the resulting
+ * xlsx file could warning for an error in the file.
+ *
+ * Be aware that there are some very generic providers already implemented:
+ * ProviderArray: To be used with an array
+ * ProviderIterator: To be used with an iterator.
+ * In both cases, to retrieve a value the helper ProviderGetValue::get() will be used.
+ *
+ * @see \XLSXExporter\Providers\ProviderArray
+ * @see \XLSXExporter\Providers\ProviderIterator
+ * @see \XLSXExporter\Utils\ProviderGetValue::get()
+ *
+ * @package XLSXExporter
+ */
 interface ProviderInterface
 {
     /**

--- a/src/XLSXExporter/Providers/ProviderArray.php
+++ b/src/XLSXExporter/Providers/ProviderArray.php
@@ -11,7 +11,7 @@ class ProviderArray implements ProviderInterface
 
     public function __construct(array $dataset)
     {
-        $this->dataset = $dataset;
+        $this->dataset = array_values($dataset);
         $this->index = 0;
     }
 

--- a/src/XLSXExporter/Providers/ProviderIterator.php
+++ b/src/XLSXExporter/Providers/ProviderIterator.php
@@ -23,6 +23,8 @@ class ProviderIterator implements ProviderInterface
 {
     /** @var Iterator */
     private $iterator;
+
+    /** @var int */
     private $count;
 
     /**
@@ -34,7 +36,11 @@ class ProviderIterator implements ProviderInterface
     {
         $this->iterator = $iterator;
         if (! is_int($count) || $count < 0) {
-            $count = $this->obtainCountFromIterator();
+            if ($this->iterator instanceof \Countable) {
+                $count = $this->iterator->count();
+            } else {
+                $count = $this->obtainCountFromIterator();
+            }
         }
         $this->count = $count;
     }

--- a/src/XLSXExporter/SharedStrings.php
+++ b/src/XLSXExporter/SharedStrings.php
@@ -13,6 +13,7 @@ class SharedStrings implements \Countable
 {
     /** @var int */
     protected $count = 0;
+
     /** @var string[] */
     protected $strings = [];
 

--- a/src/XLSXExporter/Styles/AbstractStyle.php
+++ b/src/XLSXExporter/Styles/AbstractStyle.php
@@ -4,8 +4,7 @@ namespace XLSXExporter\Styles;
 use XLSXExporter\XLSXException;
 
 /**
- * Abstract implementation of the StyleInterface
- * Use this class
+ * Abstract implementation of the StyleInterface for internal use
  *
  * @package XLSXExporter\Styles
  */
@@ -27,9 +26,6 @@ abstract class AbstractStyle implements StyleInterface
      */
     abstract protected function properties();
 
-    /**
-     * @inheritdoc
-     */
     abstract public function asXML();
 
     public function setValues(array $array)

--- a/src/XLSXExporter/Styles/Alignment.php
+++ b/src/XLSXExporter/Styles/Alignment.php
@@ -7,6 +7,8 @@ use XLSXExporter\XLSXException;
  * @property string $horizontal Horizontal alignment
  * @property string $vertical Vertical alignment
  * @property bool $wraptext Wrap text
+ *
+ * @package XLSXExporter\Styles
  */
 class Alignment extends AbstractStyle
 {

--- a/src/XLSXExporter/Styles/Fill.php
+++ b/src/XLSXExporter/Styles/Fill.php
@@ -7,6 +7,8 @@ use XLSXExporter\XLSXException;
 /**
  * @property string $pattern Fill pattern
  * @property string $color Fill color
+ *
+ * @package XLSXExporter\Styles
  */
 class Fill extends AbstractStyle
 {

--- a/src/XLSXExporter/Styles/Font.php
+++ b/src/XLSXExporter/Styles/Font.php
@@ -13,6 +13,8 @@ use XLSXExporter\XLSXException;
  * @property string $underline Underline value (use constants)
  * @property bool $wordwrap Font is strike
  * @property string $color Font color
+ *
+ * @package XLSXExporter\Styles
  */
 class Font extends AbstractStyle
 {

--- a/src/XLSXExporter/Styles/Format.php
+++ b/src/XLSXExporter/Styles/Format.php
@@ -11,6 +11,7 @@ use XLSXExporter\Utils\XmlConverter;
  * http://msdn.microsoft.com/en-us/library/documentformat.openxml.spreadsheet.numberingformat%28v=office.14%29.aspx
  * https://github.com/PHPOffice/PHPExcel/blob/develop/Classes/PHPExcel/Style/NumberFormat.php
  *
+ * @package XLSXExporter\Styles
  */
 class Format extends AbstractStyle
 {

--- a/src/XLSXExporter/Styles/Protection.php
+++ b/src/XLSXExporter/Styles/Protection.php
@@ -4,6 +4,8 @@ namespace XLSXExporter\Styles;
 /**
  * @property bool $hidden
  * @property bool $locked
+ *
+ * @package XLSXExporter\Styles
  */
 class Protection extends AbstractStyle
 {

--- a/src/XLSXExporter/Utils/ProviderGetValue.php
+++ b/src/XLSXExporter/Utils/ProviderGetValue.php
@@ -4,7 +4,7 @@ namespace XLSXExporter\Utils;
 class ProviderGetValue
 {
     /**
-     * Retrieve a key from an array-key, ArrayAccess object or a object property
+     * Retrieve a value from a key-value array, an ArrayAccess object or an object property
      *
      * @param mixed $values
      * @param string $key

--- a/tests/XLSXExporterTests/Providers/ProviderArrayTest.php
+++ b/tests/XLSXExporterTests/Providers/ProviderArrayTest.php
@@ -1,0 +1,45 @@
+<?php
+namespace XLSXExporterTests\Providers;
+
+use PHPUnit\Framework\TestCase;
+use XLSXExporter\Providers\ProviderArray;
+
+class ProviderArrayTest extends TestCase
+{
+    public function testProviderArray()
+    {
+        $provider = new ProviderArray([
+            ['a' => 'foo', 'b' => 1],
+            ['a' => 'bar', 'b' => 2],
+        ]);
+
+        $this->assertTrue($provider->valid());
+        $this->assertEquals('foo', $provider->get('a'));
+        $this->assertEquals(1, $provider->get('b'));
+        $provider->next();
+        $this->assertTrue($provider->valid());
+        $this->assertEquals('bar', $provider->get('a'));
+        $this->assertEquals(2, $provider->get('b'));
+        $provider->next();
+        $this->assertFalse($provider->valid());
+    }
+
+    public function testProviderArrayWithKeys()
+    {
+        $provider = new ProviderArray([
+            99 => ['a' => 'foo', 'b' => 1],
+            'x' => ['a' => 'bar', 'b' => 2],
+        ]);
+
+        $this->assertTrue($provider->valid());
+        $this->assertEquals('foo', $provider->get('a'));
+        $this->assertEquals(1, $provider->get('b'));
+        $provider->next();
+        $this->assertTrue($provider->valid());
+        $this->assertEquals('bar', $provider->get('a'));
+        $this->assertEquals(2, $provider->get('b'));
+        $provider->next();
+        $this->assertFalse($provider->valid());
+    }
+
+}

--- a/tests/XLSXExporterTests/Providers/ProviderArrayTest.php
+++ b/tests/XLSXExporterTests/Providers/ProviderArrayTest.php
@@ -41,5 +41,4 @@ class ProviderArrayTest extends TestCase
         $provider->next();
         $this->assertFalse($provider->valid());
     }
-
 }


### PR DESCRIPTION
- Fix bug when the array in the ProviderArray has non consecutive keys
- Improve ProviderIterator, use count() method if the $iterator parameter is an instance of \Countable
- Set composer specific versions, remove scrutinizer/ocular from dev, install only on inside travis build
- Minor changes in typos, dockblocks and code style