### PR TITLE
Version 1.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Version 1.5.6
 - Add ResultProvider to use a DBAL\Result as the source of a Provider
 - ResultProvider does not implement its own methods, it simply extends ProviderIterator
-- RecordsetProvider does not use its own implementarion, now it extends ProviderIterator
+- RecordsetProvider does not use its own implementation, now it extends ProviderIterator
   since the DBAL\Ŗecordset objects implements the \IteratorAggregate interface
 - ProviderInterface has a method count, make it extends \Countable
 - Styles\Alignment write wrapText attribute if it was set, was only written if was true
+- Remove docblock for casting \DBAL\Result->getIterator to \Iterator (fixed in upstream)
 
 # Version 1.5.5
 - Fix bug when the array in the ProviderArray has non consecutive keys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 1.5.6
+- Add ResultProvider to use a DBAL\Result as the source of a Provider
+- ResultProvider does not implement its own methods, it simply extends ProviderIterator
+- RecordsetProvider does not use its own implementarion, now it extends ProviderIterator
+  since the DBAL\Ŗecordset objects implements the \IteratorAggregate interface
+- ProviderInterface has a method count, make it extends \Countable
+- Styles\Alignment write wrapText attribute if it was set, was only written if was true
+
 # Version 1.5.5
 - Fix bug when the array in the ProviderArray has non consecutive keys
 - Improve ProviderIterator, use count() method if the $iterator parameter is an instance of \Countable

--- a/src/XLSXExporter/DBAL/RecordsetProvider.php
+++ b/src/XLSXExporter/DBAL/RecordsetProvider.php
@@ -3,40 +3,18 @@ namespace XLSXExporter\DBAL;
 
 use EngineWorks\DBAL\Recordset;
 use XLSXExporter\ProviderInterface;
+use XLSXExporter\Providers\ProviderIterator;
 
 /**
  * The RecordsetProvider uses a Recordset object as a Provider
- * Important: This class will not move the current record but forward (it will not rewind)
+ * Important: This class will export from the current record and move forward, it will not move first
  *
  * @package XLSXExporter\DBAL
  */
-class RecordsetProvider implements ProviderInterface
+class RecordsetProvider extends ProviderIterator implements ProviderInterface
 {
-    /** @var Recordset */
-    private $recordset;
-
     public function __construct(Recordset $recordset)
     {
-        $this->recordset = $recordset;
-    }
-
-    public function count()
-    {
-        return $this->recordset->getRecordCount();
-    }
-
-    public function get($key)
-    {
-        return (array_key_exists($key, $this->recordset->values)) ? $this->recordset->values[$key] : null;
-    }
-
-    public function next()
-    {
-        $this->recordset->moveNext();
-    }
-
-    public function valid()
-    {
-        return (! $this->recordset->eof());
+        parent::__construct($recordset->getIterator(), $recordset->getRecordCount());
     }
 }

--- a/src/XLSXExporter/DBAL/ResultProvider.php
+++ b/src/XLSXExporter/DBAL/ResultProvider.php
@@ -16,7 +16,6 @@ class ResultProvider extends ProviderIterator implements ProviderInterface
 {
     public function __construct(Result $result)
     {
-        /* @var \Iterator $iterator */
         $iterator = $result->getIterator();
         if (! $iterator->valid()) {
             $iterator->rewind();

--- a/src/XLSXExporter/DBAL/ResultProvider.php
+++ b/src/XLSXExporter/DBAL/ResultProvider.php
@@ -1,0 +1,26 @@
+<?php
+namespace XLSXExporter\DBAL;
+
+use EngineWorks\DBAL\Result;
+use XLSXExporter\ProviderInterface;
+use XLSXExporter\Providers\ProviderIterator;
+
+/**
+ * The ResultProvider uses a Result object as a Provider
+ * Important: This class will export from the current record and move forward
+ * If there is no current record (iterator is not valid) then it will call rewind
+ *
+ * @package XLSXExporter\DBAL
+ */
+class ResultProvider extends ProviderIterator implements ProviderInterface
+{
+    public function __construct(Result $result)
+    {
+        /* @var \Iterator $iterator */
+        $iterator = $result->getIterator();
+        if (! $iterator->valid()) {
+            $iterator->rewind();
+        }
+        parent::__construct($iterator, $result->count());
+    }
+}

--- a/src/XLSXExporter/ProviderInterface.php
+++ b/src/XLSXExporter/ProviderInterface.php
@@ -27,7 +27,7 @@ namespace XLSXExporter;
  *
  * @package XLSXExporter
  */
-interface ProviderInterface
+interface ProviderInterface extends \Countable
 {
     /**
      * Get a value of the current tuple based on the key

--- a/src/XLSXExporter/Styles/Alignment.php
+++ b/src/XLSXExporter/Styles/Alignment.php
@@ -36,7 +36,7 @@ class Alignment extends AbstractStyle
         return '<alignment'
             . (($this->horizontal) ? ' horizontal="' . $this->horizontal . '"' : '')
             . (($this->vertical) ? ' vertical="' . $this->vertical . '"' : '')
-            . (($this->wraptext) ? ' wrapText="' . (($this->wraptext) ? '1' : '0') . '"' : '')
+            . ((null !== $this->wraptext) ? ' wrapText="' . (($this->wraptext) ? '1' : '0') . '"' : '')
             . '/>'
         ;
     }

--- a/tests/XLSXExporterTests/DBAL/RecordsetProviderTest.php
+++ b/tests/XLSXExporterTests/DBAL/RecordsetProviderTest.php
@@ -16,6 +16,7 @@ class RecordsetProviderTest extends TestCase
         $provider = new RecordsetProvider($recordset);
 
         $this->assertInstanceOf(ProviderInterface::class, $provider);
+        $this->assertTrue($provider->valid());
         $this->assertSame(3, $provider->count());
         $expectedResults = [
             ['EmployeeId' => 3, 'FirstName' => 'Jane', 'LastName' => 'Peacock', 'Null' => null],

--- a/tests/XLSXExporterTests/DBAL/ResultProviderTest.php
+++ b/tests/XLSXExporterTests/DBAL/ResultProviderTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace XLSXExporterTests\DBAL;
+
+use PHPUnit\Framework\TestCase;
+use XLSXExporter\DBAL\ResultProvider;
+use XLSXExporter\ProviderInterface;
+use XLSXExporterTests\TestUtils;
+
+class ResultProviderTest extends TestCase
+{
+    public function testProviderImplementation()
+    {
+        $dbal = TestUtils::getDBAL();
+        $sql = 'SELECT ' . 'EmployeeId, FirstName, LastName FROM employees WHERE ReportsTo = 2 ORDER BY EmployeeId;';
+        $result = $dbal->queryResult($sql);
+        $provider = new ResultProvider($result);
+
+        $this->assertInstanceOf(ProviderInterface::class, $provider);
+        $this->assertTrue($provider->valid());
+        $this->assertSame(3, $provider->count());
+        $expectedResults = [
+            ['EmployeeId' => 3, 'FirstName' => 'Jane', 'LastName' => 'Peacock', 'Null' => null],
+            ['EmployeeId' => 4, 'FirstName' => 'Margaret', 'LastName' => 'Park', 'Null' => null],
+            ['EmployeeId' => 5, 'FirstName' => 'Steve', 'LastName' => 'Johnson', 'Null' => null],
+        ];
+        $retrieved = [];
+        while ($provider->valid()) {
+            $retrieved[] = [
+                'EmployeeId' => $provider->get('EmployeeId'),
+                'FirstName' => $provider->get('FirstName'),
+                'LastName' => $provider->get('LastName'),
+                'Null' => $provider->get('Null'),
+            ];
+            $provider->next();
+        }
+        $this->assertEquals($expectedResults, $retrieved);
+    }
+}

--- a/tests/XLSXExporterTests/Providers/ProviderArrayTest.php
+++ b/tests/XLSXExporterTests/Providers/ProviderArrayTest.php
@@ -13,6 +13,7 @@ class ProviderArrayTest extends TestCase
             ['a' => 'bar', 'b' => 2],
         ]);
 
+        // simulate loop in iterator
         $this->assertTrue($provider->valid());
         $this->assertEquals('foo', $provider->get('a'));
         $this->assertEquals(1, $provider->get('b'));
@@ -22,6 +23,9 @@ class ProviderArrayTest extends TestCase
         $this->assertEquals(2, $provider->get('b'));
         $provider->next();
         $this->assertFalse($provider->valid());
+
+        // get returns null when not valid
+        $this->assertNull($provider->get('a'));
     }
 
     public function testProviderArrayWithKeys()
@@ -31,6 +35,7 @@ class ProviderArrayTest extends TestCase
             'x' => ['a' => 'bar', 'b' => 2],
         ]);
 
+        // simulate loop in iterator
         $this->assertTrue($provider->valid());
         $this->assertEquals('foo', $provider->get('a'));
         $this->assertEquals(1, $provider->get('b'));
@@ -40,5 +45,8 @@ class ProviderArrayTest extends TestCase
         $this->assertEquals(2, $provider->get('b'));
         $provider->next();
         $this->assertFalse($provider->valid());
+
+        // get returns null when not valid
+        $this->assertNull($provider->get('a'));
     }
 }

--- a/tests/XLSXExporterTests/Providers/ProviderIteratorTest.php
+++ b/tests/XLSXExporterTests/Providers/ProviderIteratorTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace XLSXExporterTests\Providers;
+
+use PHPUnit\Framework\TestCase;
+use XLSXExporter\Providers\ProviderIterator;
+
+class ProviderIteratorTest extends TestCase
+{
+    public function testProviderArray()
+    {
+        // create an iterator that is not countable, (ArrayIterator is)
+        $noCountableIterator = new \IteratorIterator(new \ArrayIterator([
+            ['a' => 'foo', 'b' => 1],
+            ['a' => 'bar', 'b' => 2],
+        ]));
+        $this->assertNotInstanceOf(\Countable::class, $noCountableIterator);
+        $this->assertInstanceOf(\Iterator::class, $noCountableIterator);
+        $provider = new ProviderIterator($noCountableIterator);
+        $this->assertEquals(2, $provider->count());
+
+        // simulate loop in iterator
+        $this->assertTrue($provider->valid());
+        $this->assertEquals('foo', $provider->get('a'));
+        $this->assertEquals(1, $provider->get('b'));
+        $provider->next();
+        $this->assertTrue($provider->valid());
+        $this->assertEquals('bar', $provider->get('a'));
+        $this->assertEquals(2, $provider->get('b'));
+        $provider->next();
+        $this->assertFalse($provider->valid());
+
+        // get returns null when not valid
+        $this->assertNull($provider->get('a'));
+    }
+}

--- a/tests/XLSXExporterTests/Styles/AlignmentTest.php
+++ b/tests/XLSXExporterTests/Styles/AlignmentTest.php
@@ -60,5 +60,4 @@ class AlignmentTest extends TestCase
         $expectedXml = '<alignment horizontal="right" vertical="bottom" wrapText="1" />';
         $this->assertXmlStringEqualsXmlString($expectedXml, $xml);
     }
-
 }

--- a/tests/XLSXExporterTests/Styles/AlignmentTest.php
+++ b/tests/XLSXExporterTests/Styles/AlignmentTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace XLSXExporterTests\Styles;
+
+use PHPUnit\Framework\TestCase;
+use XLSXExporter\Styles\Alignment;
+use XLSXExporter\Styles\StyleInterface;
+use XLSXExporter\XLSXException;
+
+class AlignmentTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $style = new Alignment();
+        $this->assertInstanceOf(StyleInterface::class, $style);
+        $this->assertNull($style->horizontal);
+        $this->assertNull($style->vertical);
+        $this->assertNull($style->wraptext);
+    }
+
+    public function testHorizontalProperty()
+    {
+        $style = new Alignment();
+        $this->assertNull($style->horizontal);
+        $style->horizontal = Alignment::HORIZONTAL_CENTER;
+        $this->assertEquals(Alignment::HORIZONTAL_CENTER, $style->horizontal);
+
+        $this->expectException(XLSXException::class);
+        $style->horizontal = Alignment::VERTICAL_BOTTOM;
+    }
+
+    public function testVerticalProperty()
+    {
+        $style = new Alignment();
+        $this->assertNull($style->vertical);
+        $style->vertical = Alignment::VERTICAL_BOTTOM;
+        $this->assertEquals(Alignment::VERTICAL_BOTTOM, $style->vertical);
+
+        $this->expectException(XLSXException::class);
+        $style->vertical = Alignment::HORIZONTAL_JUSTIFY;
+    }
+
+    public function testWraptextProperty()
+    {
+        $style = new Alignment();
+        $this->assertNull($style->wraptext);
+        $style->wraptext = true;
+        $this->assertEquals(true, $style->wraptext);
+    }
+
+    public function testSetValuesAndExportToXml()
+    {
+        $style = new Alignment();
+        $style->setValues([
+            'horizontal' => Alignment::HORIZONTAL_RIGHT,
+            'vertical' => Alignment::VERTICAL_BOTTOM,
+            'wraptext' => true,
+        ]);
+        $xml = $style->asXML();
+
+        $expectedXml = '<alignment horizontal="right" vertical="bottom" wrapText="1" />';
+        $this->assertXmlStringEqualsXmlString($expectedXml, $xml);
+    }
+
+}


### PR DESCRIPTION
- Add ResultProvider to use a DBAL\Result as the source of a Provider
- ResultProvider does not implement its own methods, it simply extends ProviderIterator
- RecordsetProvider does not use its own implementarion, now it extends ProviderIterator
  since the DBAL\Ŗecordset objects implements the \IteratorAggregate interface
- ProviderInterface has a method count, make it extends \Countable
- Styles\Alignment write wrapText attribute if it was set, was only written if was true