### PR TITLE
Maintenance 2024-01-08 (Fix GH build)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -88,7 +88,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2, phpstan
         env:
@@ -118,7 +118,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: xdebug
           tools: composer:v2
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.15.1" installed="3.15.1" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.7" installed="1.10.7" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.46.0" installed="3.46.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.8.0" installed="3.8.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.8.0" installed="3.8.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.10.55" installed="1.10.55" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -22,7 +22,7 @@ return (new PhpCsFixer\Config())
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
-        'function_typehint_space' => true,
+        'type_declaration_spaces' => true,
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 - 2023 Carlos C Soto https://eclipxe.com.mx/
+Copyright (c) 2014 - 2024 Carlos C Soto https://eclipxe.com.mx/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ This update fixes the GitHub build.
 - Update GitHub Workflow `build`:
   - Add PHP 8.3 to `phpunit` job.
   - Run jobs using PHP 8.3.
+- Update development tools.
 
 ## Version 2.0.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,11 @@ classes. The library will not export any of these objects outside its own scope.
 
 ## Unreleased changes
 
-There are no unreleased changes.
+### Maintenance 2024-01-08
+
+This update fixes the GitHub build.
+
+- Update `.php-cs-fixer.dist.php`, change rule `function_typehint_space` for `type_declaration_spaces`.
 
 ## Version 2.0.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ classes. The library will not export any of these objects outside its own scope.
 This update fixes the GitHub build.
 
 - Update `.php-cs-fixer.dist.php`, change rule `function_typehint_space` for `type_declaration_spaces`.
+- Update license year. Happy 2024!
 
 ## Version 2.0.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ This update fixes the GitHub build.
 - Update license year. Happy 2024!
 - Update GitHub Workflow `build`:
   - Add PHP 8.3 to `phpunit` job.
+  - Run jobs using PHP 8.3.
 
 ## Version 2.0.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ This update fixes the GitHub build.
 
 - Update `.php-cs-fixer.dist.php`, change rule `function_typehint_space` for `type_declaration_spaces`.
 - Update license year. Happy 2024!
+- Update GitHub Workflow `build`:
+  - Add PHP 8.3 to `phpunit` job.
 
 ## Version 2.0.0
 

--- a/src/ProviderInterface.php
+++ b/src/ProviderInterface.php
@@ -26,8 +26,8 @@ use Countable;
  * ProviderIterator: To be used with an iterator.
  * In both cases, to retrieve a value the helper ProviderGetValue::get() will be used.
  *
- * @see \Eclipxe\XlsxExporter\Providers\ProviderArray
- * @see \Eclipxe\XlsxExporter\Providers\ProviderIterator
+ * @see Providers\ProviderArray
+ * @see Providers\ProviderIterator
  * @see \Eclipxe\XlsxExporter\Utils\ProviderGetValue::get()
  */
 interface ProviderInterface extends Countable


### PR DESCRIPTION
This update fixes the GitHub build.

- Update `.php-cs-fixer.dist.php`, change rule `function_typehint_space` for `type_declaration_spaces`.
- Update license year. Happy 2024!
- Update GitHub Workflow `build`:
  - Add PHP 8.3 to `phpunit` job.
  - Run jobs using PHP 8.3.
- Update development tools.